### PR TITLE
Fix uninformative error in isValid() if token is not a string

### DIFF
--- a/build/token.js
+++ b/build/token.js
@@ -172,8 +172,8 @@ exports.remove = function() {
 exports.parse = function(token) {
   return Promise["try"](function() {
     var data, header, signature, _ref;
-    token = token.trim();
     try {
+      token = token.trim();
       _ref = token.split('.'), header = _ref[0], data = _ref[1], signature = _ref[2];
       return JSON.parse(atob(data));
     } catch (_error) {

--- a/lib/token.coffee
+++ b/lib/token.coffee
@@ -142,9 +142,8 @@ exports.remove = ->
 ###
 exports.parse = (token) ->
 	Promise.try ->
-		token = token.trim()
-
 		try
+			token = token.trim()
 			[ header, data, signature ] = token.split('.')
 			return JSON.parse(atob(data))
 		catch

--- a/tests/token.spec.coffee
+++ b/tests/token.spec.coffee
@@ -15,6 +15,15 @@ describe 'Token:', ->
 		it 'should become false if the token is invalid',  ->
 			m.chai.expect(token.isValid('hello')).to.eventually.be.false
 
+		it 'should become false if the token is a number', ->
+			m.chai.expect(token.isValid(1234)).to.eventually.be.false
+
+		it 'should become false if the token is undefined', ->
+			m.chai.expect(token.isValid(undefined)).to.eventually.be.false
+
+		it 'should become false if the token is null', ->
+			m.chai.expect(token.isValid(null)).to.eventually.be.false
+
 	describe '.set()', ->
 
 		describe 'given an invalid token', ->


### PR DESCRIPTION
This was caused because .trim() only exists for strings.
